### PR TITLE
Add description method to NSObject

### DIFF
--- a/src/objc/ns_object.rs
+++ b/src/objc/ns_object.rs
@@ -1,5 +1,6 @@
 use super::{Class, ClassType, NSUInteger, ObjCObject, Sel, BOOL};
 use crate::core::Arc;
+use crate::foundation::NSString;
 
 // TODO: Create `NSObjectProtocol` for `@protocol NSObject` and `Deref` to that.
 objc_subclass! {
@@ -85,5 +86,11 @@ impl<'data> NSObject<'data> {
     #[doc(alias = "mutableCopy")]
     pub fn mutable_copy(&self) -> Arc<Self> {
         unsafe { _msg_send_any_cached![self, mutableCopy] }
+    }
+
+    /// Returns a string that describes the contents of this object.
+    #[inline]
+    pub fn description(&self) -> Arc<NSString<'static>> {
+        unsafe { _msg_send_any![self, description] }
     }
 }

--- a/src/objc/ns_object.rs
+++ b/src/objc/ns_object.rs
@@ -89,6 +89,9 @@ impl<'data> NSObject<'data> {
     }
 
     /// Returns a string that describes the contents of this object.
+    ///
+    /// See [documentation](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418746-description?language=objc)
+    #[cfg(feature = "foundation")]
     #[inline]
     pub fn description(&self) -> Arc<NSString<'static>> {
         unsafe { _msg_send_any![self, description] }

--- a/src/objc/ns_object.rs
+++ b/src/objc/ns_object.rs
@@ -96,4 +96,14 @@ impl<'data> NSObject<'data> {
     pub fn description(&self) -> Arc<NSString<'static>> {
         unsafe { _msg_send_any![self, description] }
     }
+
+    /// Returns a string that describes the contents of the receiver for
+    /// presentation in the debugger.
+    ///
+    /// See [documentation](https://developer.apple.com/documentation/objectivec/1418956-nsobject?language=objc)
+    #[cfg(feature = "foundation")]
+    #[inline]
+    pub fn debug_description(&self) -> Arc<NSString<'static>> {
+        unsafe { _msg_send_any![self, debugDescription] }
+    }
 }


### PR DESCRIPTION
This adds the `description` method to `NSObject`, which invokes the
`description` selector.