### PR TITLE
Add support for Objective-C generics and NSArray

### DIFF
--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -17,6 +17,7 @@ pub mod error_codes;
 
 mod cmp;
 mod geometry;
+mod ns_array;
 mod ns_error;
 mod ns_exception;
 mod ns_null;
@@ -26,6 +27,7 @@ mod ns_value;
 
 pub use cmp::*;
 pub use geometry::*;
+pub use ns_array::*;
 pub use ns_error::*;
 pub use ns_exception::*;
 pub use ns_null::*;

--- a/src/foundation/ns_array/macros.rs
+++ b/src/foundation/ns_array/macros.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! ns_array {
+    ($s: expr) => {{
+        
+    }}
+}

--- a/src/foundation/ns_array/mod.rs
+++ b/src/foundation/ns_array/mod.rs
@@ -1,0 +1,22 @@
+use crate::core::Arc;
+use crate::core::ObjectType;
+use crate::objc::{NSObject, NSUInteger};
+
+objc_subclass! {
+    /// A static ordered collection of objects.
+    ///
+    // See [documentation](https://developer.apple.com/documentation/foundation/nsarray?language=objc)
+    pub class NSArray<'data, T>: NSObject<'data>;
+}
+
+impl<'a, T: ObjectType> NSArray<'a, T> {
+    /// The number of objects in the array.
+    pub fn count(&self) -> NSUInteger {
+        unsafe { _msg_send_any![self, count] }
+    }
+
+    /// Returns the object located at the specified index.
+    pub fn object_at_index(&self, index: NSUInteger) -> Arc<T> {
+        unsafe { _msg_send_any![self, object_at_index: index] }
+    }
+}


### PR DESCRIPTION
This change first adds support for declaring rust counterparts for Objective-C
classes that include generics.

Second, the change adds NSArray as a motivating example and use case.

Unfortunately, this set of changes does not compile due to lifetime constraints
not being satisfied. I am looking for guidance on how to resolve the lifetime
issues. What is the appropriate lifetime relationship to represent between
objects stored in NSArray and NSArray's lifetime captured in the PhantomData of NSArray?
How should Arc wrap them when accessing objects?