### PR TITLE
Allow compiling on windows

### DIFF
--- a/src/core_graphics/mod.rs
+++ b/src/core_graphics/mod.rs
@@ -7,7 +7,8 @@
 
 #![cfg(feature = "core_graphics")]
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(target_vendor = "apple", link(name = "CoreGraphics", kind = "framework"))]
+#[cfg_attr(not(target_vendor = "apple"), link(name = "CoreGraphics"))]
 extern "C" {}
 
 mod geometry;

--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -52,5 +52,6 @@ pub type NSTimeInterval = f64;
 #[allow(non_upper_case_globals)]
 pub const NSNotFound: crate::objc::NSInteger = crate::objc::NSIntegerMax;
 
-#[link(name = "Foundation", kind = "framework")]
+#[cfg_attr(target_vendor = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(not(target_vendor = "apple"), link(name = "Foundation"))]
 extern "C" {}

--- a/src/foundation/ns_number.rs
+++ b/src/foundation/ns_number.rs
@@ -107,6 +107,7 @@ impl From<c_uint> for Arc<NSNumber> {
     }
 }
 
+#[cfg(not(windows))] // On windows, c_long and c_int are the same type.
 impl From<c_long> for Arc<NSNumber> {
     #[inline]
     fn from(value: c_long) -> Self {
@@ -114,6 +115,7 @@ impl From<c_long> for Arc<NSNumber> {
     }
 }
 
+#[cfg(not(windows))] // On windows, c_ulong and c_uint are the same type.
 impl From<c_ulong> for Arc<NSNumber> {
     #[inline]
     fn from(value: c_ulong) -> Self {


### PR DESCRIPTION
On windows, c_long and c_int are the same types. As currently written, fruity fails to compile due to conflicting implementations of `From<T> for Arc<NSNumber>`

As a simple workaround, disable one of the conflicting implementations when building for windows.